### PR TITLE
Feature/remove direct emdk dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,13 @@ YWR2ZW50dXJlZmF0aGVycm9vdHBhc3R0cmFjZWVhY2hydWJiZXJoYWRldmVudGNoZWNrdGVhY2hlcmV4
     There are several cases where this error can occur, see below
   
   - *statusCode CHECK_XML*
-  
+
+    Either:
+    With sub-error "Not allowed to access MXMF, CSP Manager is not ready"
+    The EMDK takes a minute or so from boot to it is ready, so if we try to access device serial too early it will fail
+    Will resolve itself once EMDK is ready
+
+    Or:
     Due to CallerSignature not matching signature of app.
     To get signature of app, you can use Zebras own Sigtools.jar and convert the result to base64 instructions found here: https://techdocs.zebra.com/emdk-for-android/latest/samples/sigtools/
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get the kemdk library you also need to add a reference to jitpak:
 In the dependencies of your app you need to reference the implementation of the kemdk library
 ```
 /* EMDK */
-val emdkVersion = "1.0.0"
+val emdkVersion = "1.0.1"
 implementation("com.github.gls-denmark:kotlin-emdk:$emdkVersion")
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ To get the kemdk library you also need to add a reference to jitpak:
 
 #### app build.gradle
 In the dependencies of your app you need to reference the implementation of the kemdk library
+You can see the available versions at https://jitpack.io/#gls-denmark/kotlin-emdk
 ```
 /* EMDK */
-val emdkVersion = "1.0.1"
+val emdkVersion = "1.0.1" 
 implementation("com.github.gls-denmark:kotlin-emdk:$emdkVersion")
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,9 +63,10 @@ dependencies {
     This project will not build if the desired version does not exist in repository
     Therefore we can start building with direct reference to the project
     Once build and published, we can test the uploaded library by referring to the repository instead
+    See https://jitpack.io/#gls-denmark/kotlin-emdk for available versions
      */
 
-//    def emdk_version = "1.0.1"
+//    def emdk_version = "x.y.z"
 //    implementation "com.github.gls-denmark:kotlin-emdk:$emdk_version"
     implementation project(':kemdk')
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,13 +65,9 @@ dependencies {
     Once build and published, we can test the uploaded library by referring to the repository instead
      */
 
-//    def emdk_version = "1.0.0"
+//    def emdk_version = "1.0.1"
 //    implementation "com.github.gls-denmark:kotlin-emdk:$emdk_version"
     implementation project(':kemdk')
-
-    //Scanner
-    def emdk_version = "9.1.1"
-    compileOnly "com.symbol:emdk:$emdk_version"
 
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1"
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.1"

--- a/app/src/main/java/dk/gls/kotlin_emdk/EMDKViewModel.kt
+++ b/app/src/main/java/dk/gls/kotlin_emdk/EMDKViewModel.kt
@@ -37,7 +37,7 @@ class EMDKViewModel() : ViewModel() {
 
                         is EMDKThrowable.ProfileXMLThrowable -> {
                             val error = result.error as EMDKThrowable.ProfileXMLThrowable
-                            _deviceResultStateFlow.update { UIState.Error(error.emdkResult?.extendedStatusMessage) }
+                            _deviceResultStateFlow.update { UIState.Error(error.emdkConfigError?.extendedConfigError) }
                         }
 
                         is EMDKThrowable.UnableToRetrieveSerial -> {

--- a/kemdk/build.gradle
+++ b/kemdk/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'maven-publish'
 }
 
-version = "0.0.1"
+version = "1.0.1"
 
 android {
     namespace 'dk.gls.kemdk'

--- a/kemdk/build.gradle
+++ b/kemdk/build.gradle
@@ -11,8 +11,6 @@ plugins {
     id 'maven-publish'
 }
 
-version = "1.0.1"
-
 android {
     namespace 'dk.gls.kemdk'
     compileSdk 33

--- a/kemdk/src/main/java/dk/gls/kemdk/DeviceSerialUtil.kt
+++ b/kemdk/src/main/java/dk/gls/kemdk/DeviceSerialUtil.kt
@@ -105,7 +105,8 @@ class DeviceSerialUtil(val context: Context) {
                                 )
                                 if (continuation.isActive) {
                                     continuation.resume(
-                                        EMDKThrowable.ProfileXMLThrowable(result).toKEMDKFailure()
+                                        EMDKThrowable.ProfileXMLThrowable(result?.toConfigError())
+                                            .toKEMDKFailure()
                                     )
                                 }
                             }

--- a/kemdk/src/main/java/dk/gls/kemdk/EMDKThrowable.kt
+++ b/kemdk/src/main/java/dk/gls/kemdk/EMDKThrowable.kt
@@ -13,7 +13,7 @@ sealed class EMDKThrowable : Throwable() {
      * ProfileXMLThrowable is related to errors in the EDMKConfig.xml
      * See Readme for troubleshooting
      */
-    class ProfileXMLThrowable(val emdkResult: EMDKResults?) : EMDKThrowable()
+    class ProfileXMLThrowable(val emdkConfigError: EMDKConfigError?) : EMDKThrowable()
 
     /**
      * UnableToRetrieveSerial happens when there is an error retrieving the device serial
@@ -21,4 +21,16 @@ sealed class EMDKThrowable : Throwable() {
      * See Readme for troubleshooting
      */
     class UnableToRetrieveSerial(val serialResult: String?) : EMDKThrowable()
+}
+
+data class EMDKConfigError(
+    val configError: String,
+    val extendedConfigError: String
+)
+
+fun EMDKResults.toConfigError(): EMDKConfigError {
+    return EMDKConfigError(
+        configError = statusString,
+        extendedConfigError = extendedStatusMessage
+    )
 }


### PR DESCRIPTION
To avoid having our project depend on emdk as well as this lib, we create a wrapper class for the errors returned in some cases